### PR TITLE
Problem: fty-alert-list never delivered a tmpfiles config

### DIFF
--- a/install.xml
+++ b/install.xml
@@ -1,0 +1,14 @@
+<!--
+Installation model
+
+    1. by path & name
+    path - absolute path to the file
+    name - file name
+
+    2. type
+    * systemd-tmpfiles  - install $(project.name) to /usr/lib/tmpfiles.d/
+     -->
+
+<install>
+    <item type = "systemd-tmpfiles" />
+</install>

--- a/src/fty-alert-list.conf
+++ b/src/fty-alert-list.conf
@@ -1,0 +1,3 @@
+# create runtime directories for fty-alert-list
+d /var/lib/fty/fty-alert-list 0755 bios root
+x /var/lib/fty/fty-alert-list/*

--- a/src/fty-alert-list.service.in
+++ b/src/fty-alert-list.service.in
@@ -1,18 +1,19 @@
 [Unit]
 Description=fty-alert-list service
-Requires=malamute.service
-After=malamute.service
+Requires=network.target malamute.service
+After=network.target malamute.service
 PartOf=bios.target
 
 [Service]
 Type=simple
-User=nobody
+User=bios
 EnvironmentFile=-/etc/default/bios
 EnvironmentFile=-/etc/sysconfig/bios
 EnvironmentFile=-/etc/default/bios__%n.conf
 EnvironmentFile=-/etc/sysconfig/bios__%n.conf
 Environment="prefix=@prefix@"
-ExecStart=@prefix@/bin/fty-alert-list 
+ExecStart=@prefix@/bin/fty-alert-list
+Restart=always
 
 [Install]
 WantedBy=bios.target

--- a/src/fty-alert-list.service.in
+++ b/src/fty-alert-list.service.in
@@ -7,13 +7,17 @@ PartOf=bios.target
 [Service]
 Type=simple
 User=bios
-EnvironmentFile=-/etc/default/bios
-EnvironmentFile=-/etc/sysconfig/bios
-EnvironmentFile=-/etc/default/bios__%n.conf
-EnvironmentFile=-/etc/sysconfig/bios__%n.conf
+Restart=always
+EnvironmentFile=-@prefix@/share/bios/etc/default/bios
+EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
+EnvironmentFile=-@prefix@/share/fty/etc/default/fty
+EnvironmentFile=-@prefix@/share/fty/etc/default/fty__%n.conf
+EnvironmentFile=-@sysconfdir@/default/bios
+EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
+EnvironmentFile=-@sysconfdir@/default/fty
+EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
 ExecStart=@prefix@/bin/fty-alert-list
-Restart=always
 
 [Install]
 WantedBy=bios.target

--- a/src/fty_alert_list_server.c
+++ b/src/fty_alert_list_server.c
@@ -31,7 +31,7 @@
 #define RFC_ALERTS_LIST_SUBJECT "rfc-alerts-list"
 #define RFC_ALERTS_ACKNOWLEDGE_SUBJECT  "rfc-alerts-acknowledge"
 
-static const char *STATE_PATH = "/var/lib/bios/agent-alerts-list";
+static const char *STATE_PATH = "/var/lib/fty/fty-alert-list";
 static const char *STATE_FILE = "state_file";
 
 static void
@@ -68,7 +68,7 @@ s_clear_long_time_expired (zhash_t *exp) {
 
     zlist_t *keys = zhash_keys(exp);
     int64_t now = zclock_mono ()/1000;
-    
+
     const char *rule = (char *)zlist_first (keys);
     while (rule) {
         int64_t *time = (int64_t *) zhash_lookup (exp, rule);
@@ -448,7 +448,7 @@ fty_alert_list_server (zsock_t *pipe, void *args)
             }
         }
     }
-    
+
     rv = alert_save_state (alerts, STATE_PATH, STATE_FILE);
     zsys_debug ("alert_save_state () == %d", rv);
 


### PR DESCRIPTION
Solution: create the tmpfiles config, install it, and use matching runtime user account for the service.