### PR TITLE
Problem: recent czmq4-related fixes followed different patterns

### DIFF
--- a/src/alerts_utils.c
+++ b/src/alerts_utils.c
@@ -435,16 +435,27 @@ alert_load_state (zlistx_t *alerts, const char *path, const char *filename) {
     zfile_close (file);
     zfile_destroy (&file);
 
+    /* Note: Protocol data uses 8-byte sized words, and zmsg_XXcode and file
+     * functions deal with platform-dependent unsigned size_t and signed off_t.
+     * The off_t is a difficult one to print portably, SO suggests casting to
+     * the intmax type and printing that :)
+     * https://stackoverflow.com/questions/586928/how-should-i-print-types-like-off-t-and-size-t
+     */
     uint64_t offset = 0;
-    zsys_debug ("zfile_cursize == %d", cursize);
+    zsys_debug ("zfile_cursize == %jd", (intmax_t)cursize);
 
     while (offset < cursize) {
         byte *prefix = zframe_data (frame) + offset;
         byte *data = zframe_data (frame) + offset + sizeof (uint64_t);
         offset += (uint64_t) *prefix +  sizeof (uint64_t);
-        zsys_debug ("prefix == %d; offset = %d ", (uint64_t ) *prefix, offset);
+        zsys_debug ("prefix == %" PRIu64 "; offset = %" PRIu64 " ", (uint64_t ) *prefix, offset);
 
-        zmsg_t *zmessage;
+/* Note: the CZMQ_VERSION_MAJOR comparison below actually assumes versions
+ * we know and care about - v3.0.2 (our legacy default, already obsoleted
+ * by upstream), and v4.x that is in current upstream master. If the API
+ * evolves later (incompatibly), these macros will need to be amended.
+ */
+        zmsg_t *zmessage = NULL;
 #if CZMQ_VERSION_MAJOR == 3
         zmessage = zmsg_decode (data, (size_t) *prefix);
 #else
@@ -503,28 +514,38 @@ alert_save_state (zlistx_t *alerts, const char *path, const char *filename) {
     fty_proto_t *cursor = (fty_proto_t *) zlistx_first (alerts);
     fty_proto_print (cursor);
     while (cursor) {
+        uint64_t size = 0;  // Note: the zmsg_encode() and zframe_size()
+                            // below return a platform-dependent size_t,
+                            // but in protocol we use fixed uint64_t
+        assert ( sizeof(size_t) <= sizeof(uint64_t) );
+        zframe_t *frame = NULL;
         fty_proto_t *duplicate = fty_proto_dup (cursor);
         assert (duplicate);
         zmsg_t *zmessage = fty_proto_encode (&duplicate); // duplicate destroyed here
         assert (zmessage);
 
 #if CZMQ_VERSION_MAJOR == 3
-        byte *buffer = NULL;
-        uint64_t size = zmsg_encode (zmessage, &buffer);
-        zmsg_destroy (&zmessage);
+        {
+            byte *buffer = NULL;
+            size = zmsg_encode (zmessage, &buffer);
 
-        assert (buffer);
-        assert (size > 0);
-        zframe_t *frame = zframe_new (buffer, size);
-        free (buffer); buffer = NULL;
+            assert (buffer);
+            assert (size > 0);
+            frame = zframe_new (buffer, size);
+            free (buffer);
+            buffer = NULL;
+        }
 #else
-        zframe_t *frame = zmsg_encode (zmessage);
-        uint64_t size = zframe_size (frame);
-        zmsg_destroy (&zmessage);
+        frame = zmsg_encode (zmessage);
+        size = zframe_size (frame);
 #endif
+        zmsg_destroy (&zmessage);
         assert (frame);
+        assert (size > 0);
 
         // prefix
+// FIXME?: originally this was for uint64_t, should it be sizeof (size) instead?
+// Also is usage of uint64_t here really warranted (e.g. dictated by protocol)?
         zchunk_extend (chunk, (const void *) &size, sizeof (uint64_t));
         // data
         zchunk_extend (chunk, (const void *) zframe_data (frame), size);

--- a/src/fty_alert_list_convert.c
+++ b/src/fty_alert_list_convert.c
@@ -73,10 +73,16 @@ convert_file (const char *file_name, const char *old_path, const char *new_path)
     zfile_close (file);
     zfile_destroy (&file);
 
+   /* Note: Protocol data uses 8-byte sized words, and zmsg_XXcode and file
+    * functions deal with platform-dependent unsigned size_t and signed off_t.
+    * The off_t is a difficult one to print portably, SO suggests casting to
+    * the intmax type and printing that :)
+    * https://stackoverflow.com/questions/586928/how-should-i-print-types-like-off-t-and-size-t
+    */
     uint64_t offset = 0;
-    zsys_debug ("zfile_cursize == %d", cursize);
+    zsys_debug ("zfile_cursize == %jd", (intmax_t)cursize);
 
-    //cunk for new state file
+    //chunk for new state file
     zchunk_t *nchunk = zchunk_new (NULL, 0);
     assert (nchunk);
 
@@ -84,9 +90,14 @@ convert_file (const char *file_name, const char *old_path, const char *new_path)
         byte *prefix = zframe_data (frame) + offset;
         byte *data = zframe_data (frame) + offset + sizeof (uint64_t);
         offset += (uint64_t) *prefix +  sizeof (uint64_t);
-        zsys_debug ("prefix == %d; offset = %d ", (uint64_t ) *prefix, offset);
+        zsys_debug ("prefix == %" PRIu64 "; offset = %" PRIu64 " ", (uint64_t ) *prefix, offset);
 
-        zmsg_t *zmessage;
+/* Note: the CZMQ_VERSION_MAJOR comparisons below actually assume versions
+ * we know and care about - v3.0.2 (our legacy default, already obsoleted
+ * by upstream), and v4.x that is in current upstream master. If the API
+ * evolves later (incompatibly), these macros will need to be amended.
+ */
+        zmsg_t *zmessage = NULL;
 #if CZMQ_VERSION_MAJOR == 3
         zmessage = zmsg_decode (data, (size_t) *prefix);
 #else
@@ -118,23 +129,34 @@ convert_file (const char *file_name, const char *old_path, const char *new_path)
         zmsg_t *zmsg = fty_proto_encode (&falert);
         assert (zmsg);
 
-#if CZMQ_VERSION_MAJOR == 3
-        byte *buffer = NULL;
-        uint64_t size = zmsg_encode (zmsg, &buffer);
-        zmsg_destroy (&zmsg);
+        uint64_t size = 0;  // Note: the zmsg_encode() and zframe_size()
+                            // below return a platform-dependent size_t,
+                            // but in protocol we use fixed uint64_t
+        assert ( sizeof(size_t) <= sizeof(uint64_t) );
+        zframe_t *nframe = NULL;
 
-        assert (buffer);
-        assert (size > 0);
-        zframe_t *nframe = zframe_new (buffer, size);
-        free (buffer); buffer = NULL;
+#if CZMQ_VERSION_MAJOR == 3
+        {
+            byte *buffer = NULL;
+            size = zmsg_encode (zmsg, &buffer);
+
+            assert (buffer);
+            assert (size > 0);
+            nframe = zframe_new (buffer, size);
+            free (buffer);
+            buffer = NULL;
+        }
 #else
-        zframe_t *nframe = zmsg_encode (zmsg);
-        uint64_t size = zframe_size (nframe);
-        zmsg_destroy (&zmsg);
+        nframe = zmsg_encode (zmsg);
+        size = zframe_size (nframe);
 #endif
+        zmsg_destroy (&zmsg);
         assert (nframe);
+        assert (size > 0);
 
         // prefix
+// FIXME: originally this was for uint64_t, should it be sizeof (size) instead?
+// Also is usage of uint64_t here really warranted (e.g. dictated by protocol)?
         zchunk_extend (nchunk, (const void *) &size, sizeof (uint64_t));
         // data
         zchunk_extend (nchunk, (const void *) zframe_data (nframe), size);


### PR DESCRIPTION
Solution:  alerts_utils.c fty_alert_list_convert.c fty_alert_list_server.c : revise and comment usage of size_t vs. uint64_t, and rearrange a bit of shared code

Note: passes with both CZMQ versions, see https://travis-ci.org/42ity/fty-alert-list/branches

This is part of revision of multiple component repos, including PRs:
* https://github.com/42ity/fty-kpi-power-uptime/pull/26
* https://github.com/42ity/fty-nut/pull/47
* https://github.com/42ity/fty-alert-list/pull/26
* https://github.com/42ity/fty-metric-cache/pull/25