### PR TITLE
Resend timing out active alerts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
             description: 'The clang-format program (v5+) to use for this build, e.g. clang-format-5.0; an empty value means configure-time guesswork',
             name: 'CLANG_FORMAT')
         string (
-            defaultValue: "10",
+            defaultValue: "30",
             description: 'When running tests, use this timeout (in minutes; be sure to leave enough for double-job of a distcheck too)',
             name: 'USE_TEST_TIMEOUT')
         booleanParam (

--- a/project.xml
+++ b/project.xml
@@ -17,6 +17,7 @@
         <option name = "test_cppcheck" value = "1" />
         <option name = "build_docs" value = "1" />
         <option name = "dist_docs" value = "1" />
+        <option name = "use_test_timeout" value = "30" />
     </target>
 
     <include filename = "license.xml" />


### PR DESCRIPTION
We need to resend any active alerts that are nearing the end of their TTL on the ALERTS stream, otherwise agents assume the alert has been resolved.