### PR TITLE
(M/L) Problem: Fty-alert-list state file stops working after translation en…

### DIFF
--- a/src/alerts_utils.cc
+++ b/src/alerts_utils.cc
@@ -1549,6 +1549,8 @@ alerts_utils_test(bool verbose) {
             zlist_destroy(&actions5);
         if (NULL != actions6)
             zlist_destroy(&actions6);
+
+        zsys_file_delete ("./test_state_file");
     }
 
     // Test case #2:

--- a/src/alerts_utils.cc
+++ b/src/alerts_utils.cc
@@ -26,6 +26,9 @@
 @end
  */
 
+#include <iostream>
+#include <fstream>
+#include <string>
 #include <fty_common_utf8.h>
 #include "fty_alert_list_classes.h"
 
@@ -181,10 +184,11 @@ s_alerts_input_checks(zlistx_t *alerts, fty_proto_t *alert) {
     return 0;
 }
 
-// load alert state from disk
+// load alert state from disk - legacy
 // 0 - success, -1 - error
 int
-alert_load_state(zlistx_t *alerts, const char *path, const char *filename) {
+s_alert_load_state_legacy (zlistx_t *alerts, const char *path, const char *filename)
+{
     assert(alerts);
     assert(path);
     assert(filename);
@@ -238,7 +242,6 @@ alert_load_state(zlistx_t *alerts, const char *path, const char *filename) {
         byte *prefix = zframe_data(frame) + offset;
         byte *data = zframe_data(frame) + offset + sizeof (uint64_t);
         offset += (uint64_t) * prefix + sizeof (uint64_t);
-        log_debug("prefix == %" PRIu64 "; offset = %jd ", (uint64_t) * prefix, (intmax_t) offset);
 
         /* Note: the CZMQ_VERSION_MAJOR comparison below actually assumes versions
          * we know and care about - v3.0.2 (our legacy default, already obsoleted
@@ -277,87 +280,145 @@ alert_load_state(zlistx_t *alerts, const char *path, const char *filename) {
     return 0;
 }
 
+int
+s_alert_load_state_new (zlistx_t *alerts, const char *path, const char *filename) {
+    if (!alerts || !path || !filename) {
+        log_error ("cannot load state");
+        return -1;
+    }
+
+    char *state_file = zsys_sprintf ("%s/%s", path, filename);
+    /* This is unrolled version of zconfig_load() which deallocates file before handing it to config
+     * in case of success.
+     * I'm not sure whether we can do this always, or whether this is specific to fty-proto state files
+     * - that's the reason for unrolling.
+     */
+    zconfig_t *state = NULL;
+    zfile_t *file = zfile_new (path, filename);
+
+    if (zfile_input (file) == 0) {
+        zchunk_t *chunk = zfile_read (file, zfile_cursize (file), 0);
+        if (chunk) {
+            state = zconfig_chunk_load (chunk);
+            zchunk_destroy (&chunk);
+            zfile_close (file);
+            zfile_destroy (&file);
+            file = NULL;        //  Config tree now owns file handle
+        }
+    }
+    zfile_destroy (&file);
+
+    if (!state) {
+        log_error ("cannot load state from file %s", state_file);
+        zconfig_destroy (&state);
+        zstr_free (&state_file);
+        return -1;
+    }
+
+    zconfig_t *cursor = zconfig_child (state);
+    if (!cursor) {
+        log_error ("no correct alert in the file %s", state_file);
+        zconfig_destroy (&state);
+        zstr_free (&state_file);
+        return -1;
+    }
+
+    log_debug ("loading alerts from file %s", state_file);
+    while (cursor) {
+        fty_proto_t *alert = fty_proto_new_zpl (cursor);
+        if (!alert) {
+            log_warning ("Ignoring malformed alert in %s", state_file);
+            cursor = zconfig_next (cursor);
+            continue;
+        }
+        fty_proto_print (alert);
+
+        if (s_alerts_input_checks (alerts, alert)) {
+            log_warning (
+                    "Alert id (%s, %s) already read.",
+                    fty_proto_rule(alert),
+                    fty_proto_name(alert));
+        }
+        else {
+            zlistx_add_end (alerts, alert);
+        }
+        cursor = zconfig_next (cursor);
+    }
+
+    zconfig_destroy (&state);
+    zstr_free (&state_file);
+    return 0;
+}
+
+int
+alert_load_state (zlistx_t *alerts, const char *path, const char *filename)
+{
+    int rv = s_alert_load_state_new (alerts, path, filename);
+    if (rv == -1)
+        rv = s_alert_load_state_legacy (alerts, path, filename);
+
+    return rv;
+}
+
+int
+s_drop_quotes_around_json (const char *state_file, const char *path, const char *filename)
+{
+    std::ifstream input_stream (state_file);
+    char *real_state_file = zsys_sprintf ("%s/%s", path, filename);
+    std::ofstream output_stream (real_state_file);
+    std::string line;
+    while (std::getline (input_stream, line)) {
+        size_t json_start = line.find ("\"{");
+        if (json_start != std::string::npos) {
+            size_t json_end = line.rfind ("}\"");
+            if (json_end != std::string::npos) {
+                line.replace (json_start, 2, " {");
+                line.replace (json_end, 2, "} ");
+            }
+        }
+        output_stream << line << std::endl;
+    }
+
+    log_debug ("storing into state file %s", real_state_file);
+    input_stream.close ();
+    zsys_file_delete (state_file);
+    output_stream.close ();
+    zstr_free (&real_state_file);
+}
+
 // save alert state to disk
 // 0 - success, -1 - error
 int
-alert_save_state(zlistx_t *alerts, const char *path, const char *filename, bool verbose) {
-    assert(alerts);
-    assert(path);
-    assert(filename);
-
-    zfile_t *file = zfile_new(path, filename);
-    if (!file) {
-        log_error("zfile_new (path = '%s', file = '%s') failed.", path, filename);
+alert_save_state(zlistx_t *alerts, const char *path, const char *filename, bool verbose)
+{
+    if (!alerts || !path || !filename) {
+        log_error ("cannot save state");
         return -1;
     }
 
-    zfile_remove(file);
-
-    if (zfile_output(file) == -1) {
-        log_error("zfile_output () failed; filename = '%s'", zfile_filename(file, NULL));
-        zfile_close(file);
-        zfile_destroy(&file);
-        return -1;
-    }
-
-    zchunk_t *chunk = zchunk_new(NULL, 0); // TODO: this can be tweaked to
-    // avoid a lot of allocs
-    assert(chunk);
-
-    fty_proto_t *cursor = (fty_proto_t *) zlistx_first(alerts);
-    if (cursor && verbose) {
-        fty_proto_print(cursor);
-    }
+    // because serialization of fty_proto_zpl adds quotes, which have to removed around JSON,
+    // write into scratch file first
+    const char *suffix = "scratch";
+    zconfig_t *state = zconfig_new ("root", NULL);
+    fty_proto_t *cursor = (fty_proto_t *) zlistx_first (alerts);
 
     while (cursor) {
-        uint64_t size = 0; // Note: the zmsg_encode() and zframe_size()
-        // below return a platform-dependent size_t,
-        // but in protocol we use fixed uint64_t
-        assert(sizeof (size_t) <= sizeof (uint64_t));
-        zframe_t *frame = NULL;
-        fty_proto_t *duplicate = fty_proto_dup(cursor);
-        assert(duplicate);
-        zmsg_t *zmessage = fty_proto_encode(&duplicate); // duplicate destroyed here
-        assert(zmessage);
-
-#if CZMQ_VERSION_MAJOR == 3
-        {
-            byte *buffer = NULL;
-            size = zmsg_encode(zmessage, &buffer);
-
-            assert(buffer);
-            assert(size > 0);
-            frame = zframe_new(buffer, size);
-            free(buffer);
-            buffer = NULL;
-        }
-#else
-        frame = zmsg_encode(zmessage);
-        size = zframe_size(frame);
-#endif
-        zmsg_destroy(&zmessage);
-        assert(frame);
-        assert(size > 0);
-
-        // prefix
-        // FIXME?: originally this was for uint64_t, should it be sizeof (size) instead?
-        // Also is usage of uint64_t here really warranted (e.g. dictated by protocol)?
-        zchunk_extend(chunk, (const void *) &size, sizeof (uint64_t));
-        // data
-        zchunk_extend(chunk, (const void *) zframe_data(frame), size);
-
-        zframe_destroy(&frame);
-
-        cursor = (fty_proto_t *) zlistx_next(alerts);
+        fty_proto_print (cursor);
+        fty_proto_zpl (cursor, state);
+        cursor = (fty_proto_t *) zlistx_next (alerts);
     }
 
-    if (zchunk_write(chunk, zfile_handle(file)) == -1) {
-        log_error("zchunk_write () failed.");
+    char *state_file = zsys_sprintf ("%s/%s.%s", path, filename, suffix);
+    int rv = zconfig_save (state, state_file);
+    if (rv == -1) {
+        zstr_free (&state_file);
+        zconfig_destroy (&state);
+        return rv;
     }
 
-    zchunk_destroy(&chunk);
-    zfile_close(file);
-    zfile_destroy(&file);
+    rv = s_drop_quotes_around_json (state_file, path, filename);
+    zstr_free (&state_file);
+    zconfig_destroy (&state);
     return 0;
 }
 
@@ -1392,17 +1453,17 @@ alerts_utils_test(bool verbose) {
 
         zlistx_destroy(&alerts);
 
-        alerts = zlistx_new();
-        assert(alerts);
-        zlistx_set_destructor(alerts, (czmq_destructor *) fty_proto_destroy);
-        zlistx_set_duplicator(alerts, (czmq_duplicator *) fty_proto_dup);
-        rv = alert_load_state(alerts, ".", "test_state_file");
+        zlistx_t *alerts2 = zlistx_new();
+        assert(alerts2);
+        zlistx_set_destructor(alerts2, (czmq_destructor *) fty_proto_destroy);
+        //zlistx_set_duplicator(alerts2, (czmq_duplicator *) fty_proto_dup);
+        rv = alert_load_state(alerts2, ".", "test_state_file");
         assert(rv == 0);
 
-        log_debug("zlistx size == %d", zlistx_size(alerts));
+        log_debug("zlistx size == %d", zlistx_size(alerts2));
 
         // Check them one by one
-        fty_proto_t *cursor = (fty_proto_t *) zlistx_first(alerts);
+        fty_proto_t *cursor = (fty_proto_t *) zlistx_first(alerts2);
         assert(streq(fty_proto_rule(cursor), "Rule1"));
         assert(streq(fty_proto_name(cursor), "Element1"));
         assert(streq(fty_proto_state(cursor), "ACTIVE"));
@@ -1413,7 +1474,7 @@ alerts_utils_test(bool verbose) {
         assert(NULL == fty_proto_action_next(cursor));
         assert(fty_proto_time(cursor) == (uint64_t) 1);
 
-        cursor = (fty_proto_t *) zlistx_next(alerts);
+        cursor = (fty_proto_t *) zlistx_next(alerts2);
         assert(streq(fty_proto_rule(cursor), "Rule1"));
         assert(streq(fty_proto_name(cursor), "Element2"));
         assert(streq(fty_proto_state(cursor), "RESOLVED"));
@@ -1424,7 +1485,7 @@ alerts_utils_test(bool verbose) {
         assert(NULL == fty_proto_action_next(cursor));
         assert(fty_proto_time(cursor) == (uint64_t) 20);
 
-        cursor = (fty_proto_t *) zlistx_next(alerts);
+        cursor = (fty_proto_t *) zlistx_next(alerts2);
         assert(streq(fty_proto_rule(cursor), "Rule2"));
         assert(streq(fty_proto_name(cursor), "Element1"));
         assert(streq(fty_proto_state(cursor), "ACK-WIP"));
@@ -1434,7 +1495,7 @@ alerts_utils_test(bool verbose) {
         assert(NULL == fty_proto_action_next(cursor));
         assert(fty_proto_time(cursor) == (uint64_t) 152452412);
 
-        cursor = (fty_proto_t *) zlistx_next(alerts);
+        cursor = (fty_proto_t *) zlistx_next(alerts2);
         assert(streq(fty_proto_rule(cursor), "Rule2"));
         assert(streq(fty_proto_name(cursor), "Element2"));
         assert(streq(fty_proto_state(cursor), "ACK-SILENCE"));
@@ -1444,7 +1505,7 @@ alerts_utils_test(bool verbose) {
         assert(NULL == fty_proto_action_next(cursor));
         assert(fty_proto_time(cursor) == (uint64_t) 5);
 
-        cursor = (fty_proto_t *) zlistx_next(alerts);
+        cursor = (fty_proto_t *) zlistx_next(alerts2);
         assert(streq(fty_proto_rule(cursor), "Rule1"));
         assert(streq(fty_proto_name(cursor), "Element3"));
         assert(streq(fty_proto_state(cursor), "RESOLVED"));
@@ -1455,7 +1516,7 @@ alerts_utils_test(bool verbose) {
         assert(NULL == fty_proto_action_next(cursor));
         assert(fty_proto_time(cursor) == (uint64_t) 50);
 
-        cursor = (fty_proto_t *) zlistx_next(alerts);
+        cursor = (fty_proto_t *) zlistx_next(alerts2);
         assert(streq(fty_proto_rule(cursor), "realpower.default"));
         assert(UTF8::utf8eq(fty_proto_name(cursor), "ŽlUťOUčKý kůň супер"));
         assert(streq(fty_proto_state(cursor), "ACTIVE"));
@@ -1465,7 +1526,8 @@ alerts_utils_test(bool verbose) {
         assert(streq(fty_proto_action_next(cursor), "SMS"));
         assert(NULL == fty_proto_action_next(cursor));
         assert(fty_proto_time(cursor) == (uint64_t) 60);
-        zlistx_destroy(&alerts);
+
+        zlistx_destroy(&alerts2);
 
         if (NULL != actions1)
             zlist_destroy(&actions1);
@@ -1492,7 +1554,6 @@ alerts_utils_test(bool verbose) {
         assert(rv == -1);
         zlistx_destroy(&alerts);
     }
-
     // State file with old format
     {
     zlistx_t *alerts = zlistx_new ();

--- a/src/alerts_utils.cc
+++ b/src/alerts_utils.cc
@@ -360,7 +360,7 @@ alert_load_state (zlistx_t *alerts, const char *path, const char *filename)
     return rv;
 }
 
-int
+void
 s_drop_quotes_around_json (const char *state_file, const char *path, const char *filename)
 {
     std::ifstream input_stream (state_file);
@@ -416,7 +416,7 @@ alert_save_state(zlistx_t *alerts, const char *path, const char *filename, bool 
         return rv;
     }
 
-    rv = s_drop_quotes_around_json (state_file, path, filename);
+    s_drop_quotes_around_json (state_file, path, filename);
     zstr_free (&state_file);
     zconfig_destroy (&state);
     return 0;

--- a/src/alerts_utils.cc
+++ b/src/alerts_utils.cc
@@ -360,6 +360,21 @@ alert_load_state (zlistx_t *alerts, const char *path, const char *filename)
     return rv;
 }
 
+/* fty_proto_zpl automatically encloses values in quotes, like this:
+
+description = "Rule changed"
+
+But JSON contains quotes on its own, and ZPL doesn't support escaping them:
+
+description = "{ "key": "Device {{var1}} does not provide expected data. It may be offline or not correctly configured.", "variables": { "var1": "sc21543331131" } }"
+
+However, ZPL doesn't require quotes and if the drop them, the value is still parsed correctly:
+
+description = { "key": "Device {{var1}} does not provide expected data. It may be offline or not correctly configured.", "variables": { "var1": "sc21543331131" } }
+
+This function drops the quotes added by fty_proto_zpl if they are enclosing JSON string.
+*/
+
 void
 s_drop_quotes_around_json (const char *state_file, const char *path, const char *filename)
 {

--- a/src/fty_alert_list_server.cc
+++ b/src/fty_alert_list_server.cc
@@ -942,9 +942,9 @@ fty_alert_list_server_test (bool verb) {
     assert (rv == 0);
 
     // Alert Lists
+    init_alert (verb);
     zactor_t *fty_al_server_stream = zactor_new (fty_alert_list_server_stream, (void *) endpoint);
     zactor_t *fty_al_server_mailbox = zactor_new (fty_alert_list_server_mailbox, (void *) endpoint);
-    init_alert (verb);
 
     // maintain a list of active alerts (that serves as "expected results")
     zlistx_t *testAlerts = zlistx_new ();
@@ -1334,7 +1334,6 @@ fty_alert_list_server_test (bool verb) {
     reply = test_request_alerts_list (ui, "RESOLVED");
     test_check_result ("RESOLVED", testAlerts, &reply, 1);
 
-
     // RESOLVED used to be an error response, but it's no more true
     zmsg_t *send = zmsg_new ();
     zmsg_addstr (send, "LIST");
@@ -1405,7 +1404,6 @@ fty_alert_list_server_test (bool verb) {
     assert (part);
     zstr_free (&part);
     zmsg_destroy (&reply);
-
 
     // Now, let's test an error response of rfc-alerts-acknowledge
     send = zmsg_new ();
@@ -1490,16 +1488,15 @@ fty_alert_list_server_test (bool verb) {
     zmsg_destroy (&reply);
 
     zlistx_destroy (&testAlerts);
-    mlm_client_destroy (&ui);
-    mlm_client_destroy (&producer);
-    mlm_client_destroy (&consumer);
 
-    zactor_destroy (&fty_al_server_stream);
-    zactor_destroy (&fty_al_server_mailbox);
-    zactor_destroy (&server);
     save_alerts ();
+    zactor_destroy (&fty_al_server_mailbox);
+    zactor_destroy (&fty_al_server_stream);
+    mlm_client_destroy (&consumer);
+    mlm_client_destroy (&producer);
+    mlm_client_destroy (&ui);
+    zactor_destroy (&server);
     destroy_alert ();
-
 
     if (NULL != actions1)
         zlist_destroy (&actions1);


### PR DESCRIPTION
…ablement.

Solution: Old model of state file assumes that binary representation of fty-proto alert always fits into 255 bytes. After jsonification of alert description, this is quite often wrong.
Therefore, this commit re-implements state file handling using ZPL support from fty-proto and zconfig support from CZMQ.
To make it work, we have to drop the quotes enclosing JSON in the state file (ZPL does not support escaping of special characters).

Signed-off-by: Jana Rapava <janarapava@eaton.com>